### PR TITLE
DD-1772 Lazy load list of licenses and active metadata blocks + wait for dependencies

### DIFF
--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -185,7 +185,9 @@ health:
       schedule:
         checkInterval: 60s
 
-
+#
+# Deposits will only proceed if these dependencies are ready. The check is done at the start of each deposit task.
+#
 dependenciesReadyCheck:
   healthChecks:
     - dataverse

--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -186,6 +186,12 @@ health:
         checkInterval: 60s
 
 
+dependenciesReadyCheck:
+  healthChecks:
+    - dataverse
+    - dd-validate-dans-bag
+  pollInterval: 5s
+
 
 #
 # See https://www.dropwizard.io/en/latest/manual/configuration.html#logging

--- a/src/main/assembly/dist/install/dd-dataverse-ingest.service
+++ b/src/main/assembly/dist/install/dd-dataverse-ingest.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Dd Dataverse Ingest Service
+Description=DD Dataverse Ingest Service
 
 [Service]
 ExecStart=/opt/dans.knaw.nl/dd-dataverse-ingest/bin/dd-dataverse-ingest server /etc/opt/dans.knaw.nl/dd-dataverse-ingest/config.yml

--- a/src/main/java/nl/knaw/dans/dvingest/DdDataverseIngestApplication.java
+++ b/src/main/java/nl/knaw/dans/dvingest/DdDataverseIngestApplication.java
@@ -111,6 +111,7 @@ public class DdDataverseIngestApplication extends Application<DdDataverseIngestC
         var dataverseIngestDepositFactory = new DataverseIngestDepositFactoryImpl(yamlService);
         var bagProcessorFactory = new BagProcessorFactoryImpl(dataverseService, utilityServices);
         var dependenciesReadyCheck = new HealthChecksDependenciesReadyCheck(environment, configuration.getDependenciesReadyCheck());
+        environment.lifecycle().manage(dependenciesReadyCheck);
 
         /*
          *  Import area

--- a/src/main/java/nl/knaw/dans/dvingest/DdDataverseIngestApplication.java
+++ b/src/main/java/nl/knaw/dans/dvingest/DdDataverseIngestApplication.java
@@ -26,7 +26,9 @@ import nl.knaw.dans.dvingest.config.DdDataverseIngestConfiguration;
 import nl.knaw.dans.dvingest.config.DepositorAuthorizationConfig;
 import nl.knaw.dans.dvingest.config.IngestAreaConfig;
 import nl.knaw.dans.dvingest.core.AutoIngestArea;
+import nl.knaw.dans.dvingest.core.DependenciesReadyCheck;
 import nl.knaw.dans.dvingest.core.IngestArea;
+import nl.knaw.dans.dvingest.core.dansbag.ActiveMetadataBlocks;
 import nl.knaw.dans.dvingest.core.dansbag.DansBagMappingService;
 import nl.knaw.dans.dvingest.core.dansbag.DansBagMappingServiceImpl;
 import nl.knaw.dans.dvingest.core.dansbag.DansDepositSupportFactory;
@@ -58,7 +60,6 @@ public class DdDataverseIngestApplication extends Application<DdDataverseIngestC
         - 'artefacten'
         - 'periodes'
  */
-
 
     public static final String SPATIAL_COVERAGE_COUNTRY_TERMS_FILENAME = "spatial-coverage-country-terms.txt";
     public static final String ISO_639_1_TO_DV_FILENAME = "iso639-1-to-dv.csv";
@@ -109,23 +110,24 @@ public class DdDataverseIngestApplication extends Application<DdDataverseIngestC
         var yamlService = new YamlServiceImpl();
         var dataverseIngestDepositFactory = new DataverseIngestDepositFactoryImpl(yamlService);
         var bagProcessorFactory = new BagProcessorFactoryImpl(dataverseService, utilityServices);
+        var dependenciesReadyCheck = new HealthChecksDependenciesReadyCheck(environment, configuration.getDependenciesReadyCheck());
 
         /*
          *  Import area
          */
         DansDepositConversionConfig dansDepositConversionConfig = configuration.getDansDepositConversion();
         var importArea = getIngestArea(configuration.getIngest().getImportConfig(), "import", environment, dansDepositConversionConfig, dataverseService, yamlService, bagProcessorFactory,
-            dataverseIngestDepositFactory);
+            dataverseIngestDepositFactory, dependenciesReadyCheck);
         /*
          * Migration area
          */
         var migrationArea = getIngestArea(configuration.getIngest().getMigration(), "migration", environment, dansDepositConversionConfig, dataverseService, yamlService, bagProcessorFactory,
-            dataverseIngestDepositFactory);
+            dataverseIngestDepositFactory, dependenciesReadyCheck);
         /*
          * Auto ingest area
          */
         var autoIngestArea = getAutoIngestArea(configuration.getIngest().getAutoIngest(), environment, dansDepositConversionConfig, dataverseService, yamlService, bagProcessorFactory,
-            dataverseIngestDepositFactory);
+            dataverseIngestDepositFactory, dependenciesReadyCheck);
 
         /*
          * Register components with Dropwizard
@@ -139,21 +141,23 @@ public class DdDataverseIngestApplication extends Application<DdDataverseIngestC
     }
 
     private AutoIngestArea getAutoIngestArea(IngestAreaConfig ingestAreaConfig, Environment environment, DansDepositConversionConfig dansDepositConversionConfig,
-        DataverseServiceImpl dataverseService, YamlServiceImpl yamlService, BagProcessorFactoryImpl bagProcessorFactory, DataverseIngestDepositFactoryImpl dataverseIngestDepositFactory) {
+        DataverseServiceImpl dataverseService, YamlServiceImpl yamlService, BagProcessorFactoryImpl bagProcessorFactory, DataverseIngestDepositFactoryImpl dataverseIngestDepositFactory,
+        DependenciesReadyCheck dependenciesReadyCheck) {
         DansDepositSupportFactory dansDepositSupportFactory = new DansDepositSupportDisabledFactory();
         if (dansDepositConversionConfig != null) {
             var dansBagMappingService = createDansBagMappingService(false, dansDepositConversionConfig, dansDepositConversionConfig.getDepositorAuthorization().getAutoIngest(), dataverseService);
             var validateDansBagService = new ValidateDansBagServiceImpl(dansDepositConversionConfig.getValidateDansBag(), false, environment);
             dansDepositSupportFactory = new DansDepositSupportFactoryImpl(validateDansBagService, dansBagMappingService, dataverseService, yamlService, ingestAreaConfig.getRequireDansBag());
         }
-        var depositTaskFactory = new DepositTaskFactoryImpl(bagProcessorFactory, dansDepositSupportFactory);
+        var depositTaskFactory = new DepositTaskFactoryImpl(bagProcessorFactory, dansDepositSupportFactory, dependenciesReadyCheck);
         var inboxTaskFactory = new InboxTaskFactoryImpl(dataverseIngestDepositFactory, depositTaskFactory, ingestAreaConfig.getOutbox());
         var inbox = Inbox.builder().inbox(ingestAreaConfig.getInbox()).taskFactory(inboxTaskFactory).build();
         return new AutoIngestArea(inbox, ingestAreaConfig.getOutbox());
     }
 
     private IngestArea getIngestArea(IngestAreaConfig ingestAreaConfig, String name, Environment environment, DansDepositConversionConfig dansDepositConversionConfig,
-        DataverseServiceImpl dataverseService, YamlServiceImpl yamlService, BagProcessorFactoryImpl bagProcessorFactory, DataverseIngestDepositFactoryImpl dataverseIngestDepositFactory) {
+        DataverseServiceImpl dataverseService, YamlServiceImpl yamlService, BagProcessorFactoryImpl bagProcessorFactory, DataverseIngestDepositFactoryImpl dataverseIngestDepositFactory,
+        DependenciesReadyCheck dependenciesReadyCheck) {
         boolean isMigration = name.equals("migration");
         DansDepositSupportFactory dansDepositSupportFactory = new DansDepositSupportDisabledFactory();
         if (dansDepositConversionConfig != null) {
@@ -162,7 +166,7 @@ public class DdDataverseIngestApplication extends Application<DdDataverseIngestC
             dansDepositSupportFactory = new DansDepositSupportFactoryImpl(validateDansBag, dansBagMappingService, dataverseService, yamlService,
                 ingestAreaConfig.getRequireDansBag());
         }
-        var depositTaskFactory = new DepositTaskFactoryImpl(bagProcessorFactory, dansDepositSupportFactory);
+        var depositTaskFactory = new DepositTaskFactoryImpl(bagProcessorFactory, dansDepositSupportFactory, dependenciesReadyCheck);
         var jobFactory = new ImportJobFactoryImpl(dataverseIngestDepositFactory, depositTaskFactory);
         return new IngestArea(jobFactory, ingestAreaConfig.getInbox(), ingestAreaConfig.getOutbox(),
             environment.lifecycle().executorService(name).minThreads(1).maxThreads(1).build());
@@ -171,28 +175,20 @@ public class DdDataverseIngestApplication extends Application<DdDataverseIngestC
     private DansBagMappingService createDansBagMappingService(boolean isMigration, DansDepositConversionConfig dansDepositConversionConfig, DepositorAuthorizationConfig depositorAuthorizationConfig,
         DataverseService dataverseService) {
         log.info("Configuring DANS Deposit conversion");
-        try {
-            var mapper = createMapper(isMigration, dansDepositConversionConfig, dataverseService);
-            return new DansBagMappingServiceImpl(
-                mapper,
-                dataverseService,
-                new SupportedLicenses(dataverseService),
-                dansDepositConversionConfig.getFileExclusionPattern() == null ? null :
-                    Pattern.compile(dansDepositConversionConfig.getFileExclusionPattern()),
-                dansDepositConversionConfig.getFilesForIndividualUploadPattern() == null ? null :
-                    Pattern.compile(dansDepositConversionConfig.getFilesForIndividualUploadPattern()),
-                dansDepositConversionConfig.getEmbargoExclusions(),
-                dansDepositConversionConfig.getAssignDepositorRole().getAutoIngest(),
-                dansDepositConversionConfig.getAssignDepositorRole().getMigration(),
-                depositorAuthorizationConfig.getPublishDataset(),
-                depositorAuthorizationConfig.getEditDataset());
-        }
-        catch (IOException e) {
-            throw new IllegalStateException("Failed to read configuration files", e);
-        }
-        catch (DataverseException e) {
-            throw new IllegalStateException("Failed to read supported licenses", e);
-        }
+        var mapper = createMapper(isMigration, dansDepositConversionConfig, dataverseService);
+        return new DansBagMappingServiceImpl(
+            mapper,
+            dataverseService,
+            new SupportedLicenses(dataverseService),
+            dansDepositConversionConfig.getFileExclusionPattern() == null ? null :
+                Pattern.compile(dansDepositConversionConfig.getFileExclusionPattern()),
+            dansDepositConversionConfig.getFilesForIndividualUploadPattern() == null ? null :
+                Pattern.compile(dansDepositConversionConfig.getFilesForIndividualUploadPattern()),
+            dansDepositConversionConfig.getEmbargoExclusions(),
+            dansDepositConversionConfig.getAssignDepositorRole().getAutoIngest(),
+            dansDepositConversionConfig.getAssignDepositorRole().getMigration(),
+            depositorAuthorizationConfig.getPublishDataset(),
+            depositorAuthorizationConfig.getEditDataset());
     }
 
     private DepositToDvDatasetMetadataMapper createMapper(boolean isMigration, DansDepositConversionConfig dansDepositConversionConfig, DataverseService dataverseService) {
@@ -201,7 +197,7 @@ public class DdDataverseIngestApplication extends Application<DdDataverseIngestC
             return new DepositToDvDatasetMetadataMapper(
                 isMigration,
                 dansDepositConversionConfig.isDeduplicate(),
-                dataverseService.getActiveMetadataBlockNames(),
+                new ActiveMetadataBlocks(dataverseService),
                 MappingLoader.builder().csvFile(mappingDefsDir.resolve(ISO_639_1_TO_DV_FILENAME)).keyColumn(ISO_639_1_TO_DV_KEY_COLUMN).valueColumn(DATAVERSE_LANGUAGE_COLUMN).build().load(),
                 MappingLoader.builder().csvFile(mappingDefsDir.resolve(ISO_639_2_TO_DV_FILENAME)).keyColumn(ISO_639_2_TO_DV_KEY_COLUMN).valueColumn(DATAVERSE_LANGUAGE_COLUMN).build().load(),
                 MappingLoader.builder().csvFile(mappingDefsDir.resolve(ABR_REPORT_CODE_TO_TERM_FILENAME)).keyColumn(CODE_COLUMN).valueColumn(SUBJECT_COLUMN).build().load(),
@@ -215,9 +211,6 @@ public class DdDataverseIngestApplication extends Application<DdDataverseIngestC
         }
         catch (IOException e) {
             throw new IllegalStateException("Failed to read configuration files", e);
-        }
-        catch (DataverseException e) {
-            throw new IllegalStateException("Failed to read supported licenses", e);
         }
     }
 }

--- a/src/main/java/nl/knaw/dans/dvingest/DepositTaskFactoryImpl.java
+++ b/src/main/java/nl/knaw/dans/dvingest/DepositTaskFactoryImpl.java
@@ -17,6 +17,7 @@ package nl.knaw.dans.dvingest;
 
 import lombok.AllArgsConstructor;
 import nl.knaw.dans.dvingest.core.DataverseIngestDeposit;
+import nl.knaw.dans.dvingest.core.DependenciesReadyCheck;
 import nl.knaw.dans.dvingest.core.DepositTask;
 import nl.knaw.dans.dvingest.core.DepositTaskFactory;
 import nl.knaw.dans.dvingest.core.bagprocessor.BagProcessorFactory;
@@ -28,9 +29,10 @@ import java.nio.file.Path;
 public class DepositTaskFactoryImpl implements DepositTaskFactory {
     private final BagProcessorFactory bagProcessorFactory;
     private final DansDepositSupportFactory dansDepositSupportFactory;
+    private final DependenciesReadyCheck dependenciesReadyCheck;
 
     @Override
     public Runnable createDepositTask(DataverseIngestDeposit deposit, Path outputDir, boolean onlyConvertDansDeposit) {
-        return new DepositTask(deposit, outputDir, onlyConvertDansDeposit, bagProcessorFactory, dansDepositSupportFactory);
+        return new DepositTask(deposit, outputDir, onlyConvertDansDeposit, bagProcessorFactory, dansDepositSupportFactory, dependenciesReadyCheck);
     }
 }

--- a/src/main/java/nl/knaw/dans/dvingest/HealthChecksDependenciesReadyCheck.java
+++ b/src/main/java/nl/knaw/dans/dvingest/HealthChecksDependenciesReadyCheck.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.dvingest;
+
+import com.codahale.metrics.health.HealthCheck;
+import io.dropwizard.core.setup.Environment;
+import lombok.extern.slf4j.Slf4j;
+import nl.knaw.dans.dvingest.config.DependenciesReadyCheckConfig;
+import nl.knaw.dans.dvingest.core.DependenciesReadyCheck;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.lang.Thread.sleep;
+
+/**
+ * Implementation of {@link DependenciesReadyCheck} that waits until all health checks are healthy.
+ */
+@Slf4j
+public class HealthChecksDependenciesReadyCheck implements DependenciesReadyCheck {
+    private final List<HealthCheck> healthChecks = new ArrayList<>();
+    private final long pollInterval;
+
+    public HealthChecksDependenciesReadyCheck(Environment environment, DependenciesReadyCheckConfig config) {
+        for (var name : config.getHealthChecks()) {
+            var healthCheck = environment.healthChecks().getHealthCheck(name);
+            if (healthCheck == null) {
+                throw new IllegalArgumentException("Health check with name " + name + " not found");
+            }
+            healthChecks.add(healthCheck);
+        }
+        pollInterval = config.getPollInterval().toMilliseconds();
+    }
+
+    @Override
+    public void waitUntilReady() {
+        while (!allHealthy()) {
+            log.warn("Not all health checks are healthy yet, waiting for {} ms", pollInterval);
+            try {
+                sleep(pollInterval);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private boolean allHealthy() {
+        for (var healthCheck : healthChecks) {
+            if (healthCheck.execute().isHealthy()) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/nl/knaw/dans/dvingest/config/DependenciesReadyCheckConfig.java
+++ b/src/main/java/nl/knaw/dans/dvingest/config/DependenciesReadyCheckConfig.java
@@ -13,33 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nl.knaw.dans.dvingest.config;
 
-import io.dropwizard.core.Configuration;
+import io.dropwizard.util.Duration;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import nl.knaw.dans.lib.util.DataverseClientFactory;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
+import java.util.List;
 
 @Data
-@EqualsAndHashCode(callSuper = true)
-public class DdDataverseIngestConfiguration extends Configuration {
-    @Valid
-    @NotNull
-    private DataverseClientFactory dataverse;
-
-    @Valid
-    @NotNull
-    private IngestConfig ingest;
-
-    @Valid
-    // NOT @NotNull, because conversion can be disabled that way
-    private DansDepositConversionConfig dansDepositConversion;
-
-    @Valid
-    @NotNull
-    private DependenciesReadyCheckConfig dependenciesReadyCheck;
+public class DependenciesReadyCheckConfig {
+    private List<String> healthChecks;
+    private Duration pollInterval;
 }

--- a/src/main/java/nl/knaw/dans/dvingest/core/DependenciesReadyCheck.java
+++ b/src/main/java/nl/knaw/dans/dvingest/core/DependenciesReadyCheck.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.dvingest.core;
+
+/**
+ * Interface for checking if all dependencies are ready.
+ */
+public interface DependenciesReadyCheck {
+    /**
+     * Wait until all dependencies are ready. This method should block until all dependencies are ready.
+     */
+    void waitUntilReady();
+}

--- a/src/main/java/nl/knaw/dans/dvingest/core/DepositTask.java
+++ b/src/main/java/nl/knaw/dans/dvingest/core/DepositTask.java
@@ -37,22 +37,25 @@ public class DepositTask implements Runnable {
     private final Path outputDir;
     private final boolean onlyConvertDansDeposit;
     private final BagProcessorFactory bagProcessorFactory;
+    private final DependenciesReadyCheck dependenciesReadyCheck;
 
     @Getter
     private Status status = Status.TODO;
 
     public DepositTask(DataverseIngestDeposit dataverseIngestDeposit, Path outputDir, boolean onlyConvertDansDeposit, BagProcessorFactory bagProcessorFactory,
-        DansDepositSupportFactory dansDepositSupportFactory) {
+        DansDepositSupportFactory dansDepositSupportFactory, DependenciesReadyCheck dependenciesReadyCheck) {
         this.deposit = dansDepositSupportFactory.addDansDepositSupportIfEnabled(dataverseIngestDeposit);
         this.outputDir = outputDir;
         this.onlyConvertDansDeposit = onlyConvertDansDeposit;
         this.bagProcessorFactory = bagProcessorFactory;
+        this.dependenciesReadyCheck = dependenciesReadyCheck;
     }
 
     @Override
     public void run() {
         String pid = null;
         try {
+            dependenciesReadyCheck.waitUntilReady();
             deposit.validate();
             if (deposit.convertDansDepositIfNeeded() && onlyConvertDansDeposit) {
                 log.info("[{}] Only converting DANS deposit, LEAVING CONVERTED DEPOSIT IN PLACE", deposit.getId());

--- a/src/main/java/nl/knaw/dans/dvingest/core/dansbag/ActiveMetadataBlocks.java
+++ b/src/main/java/nl/knaw/dans/dvingest/core/dansbag/ActiveMetadataBlocks.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.dvingest.core.dansbag;
+
+import nl.knaw.dans.dvingest.core.service.DataverseService;
+
+import java.util.Set;
+
+public class ActiveMetadataBlocks {
+    private final DataverseService dataverseService;
+    private Set<String> activeMetadataBlockNames;
+
+    public ActiveMetadataBlocks(DataverseService dataverseService) {
+        this.activeMetadataBlockNames = null;
+        this.dataverseService = dataverseService;
+    }
+
+    // FOR TESTING
+    public ActiveMetadataBlocks(Set<String> activeMetadataBlockNames) {
+        this.activeMetadataBlockNames = activeMetadataBlockNames;
+        this.dataverseService = null;
+    }
+
+    public boolean contains(String blockName) {
+        return getActiveMetadataBlockNames().contains(blockName);
+    }
+
+    public Set<String> getActiveMetadataBlockNames() {
+        if (activeMetadataBlockNames == null) {
+            try {
+                activeMetadataBlockNames = dataverseService.getActiveMetadataBlockNames();
+            }
+            catch (Exception e) {
+                throw new IllegalStateException("Could not fetch active metadata blocks from Dataverse", e);
+            }
+        }
+        return activeMetadataBlockNames;
+    }
+
+}

--- a/src/main/java/nl/knaw/dans/dvingest/core/dansbag/mapper/DepositToDvDatasetMetadataMapper.java
+++ b/src/main/java/nl/knaw/dans/dvingest/core/dansbag/mapper/DepositToDvDatasetMetadataMapper.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import nl.knaw.dans.dvingest.core.dansbag.ActiveMetadataBlocks;
 import nl.knaw.dans.dvingest.core.dansbag.deposit.VaultMetadata;
 import nl.knaw.dans.dvingest.core.dansbag.exception.MissingRequiredFieldException;
 import nl.knaw.dans.dvingest.core.dansbag.mapper.builder.ArchaeologyFieldBuilder;
@@ -91,7 +92,7 @@ public class DepositToDvDatasetMetadataMapper {
 
     private final boolean deduplicate;
     @NonNull
-    private final Set<String> activeMetadataBlocks;
+    private final ActiveMetadataBlocks activeMetadataBlocks;
     @NonNull
     private final Map<String, String> iso1ToDataverseLanguage;
     @NonNull

--- a/src/test/java/nl/knaw/dans/dvingest/core/dansbag/testhelpers/DansBagMappingServiceBuilder.java
+++ b/src/test/java/nl/knaw/dans/dvingest/core/dansbag/testhelpers/DansBagMappingServiceBuilder.java
@@ -17,6 +17,7 @@ package nl.knaw.dans.dvingest.core.dansbag.testhelpers;
 
 import lombok.Data;
 import lombok.experimental.Accessors;
+import nl.knaw.dans.dvingest.core.dansbag.ActiveMetadataBlocks;
 import nl.knaw.dans.dvingest.core.dansbag.DansBagMappingService;
 import nl.knaw.dans.dvingest.core.dansbag.DansBagMappingServiceImpl;
 import nl.knaw.dans.dvingest.core.dansbag.SupportedLicenses;
@@ -67,7 +68,7 @@ public class DansBagMappingServiceBuilder {
         var mapper = new DepositToDvDatasetMetadataMapper(
             isMigration,
             deduplicate,
-            Set.of("citation", "dansRights", "dansRelationMetadata", "dansArchaeologyMetadata", "dansTemporalSpatial", "dansDataVaultMetadata"),
+            new ActiveMetadataBlocks(Set.of("citation", "dansRights", "dansRelationMetadata", "dansArchaeologyMetadata", "dansTemporalSpatial", "dansDataVaultMetadata")),
             MappingLoader.builder().csvFile(defaultConfigDir.resolve(ISO_639_1_TO_DV_FILENAME)).keyColumn(ISO_639_1_TO_DV_KEY_COLUMN).valueColumn(DATAVERSE_LANGUAGE_COLUMN).build().load(),
             MappingLoader.builder().csvFile(defaultConfigDir.resolve(ISO_639_2_TO_DV_FILENAME)).keyColumn(ISO_639_2_TO_DV_KEY_COLUMN).valueColumn(DATAVERSE_LANGUAGE_COLUMN).build().load(),
             MappingLoader.builder().csvFile(defaultConfigDir.resolve(ABR_REPORT_CODE_TO_TERM_FILENAME)).keyColumn(CODE_COLUMN).valueColumn(SUBJECT_COLUMN).build().load(),

--- a/src/test/resources/debug-etc/config.yml
+++ b/src/test/resources/debug-etc/config.yml
@@ -158,6 +158,11 @@ health:
       schedule:
         checkInterval: 5s
 
+dependenciesReadyCheck:
+  healthChecks:
+    - dataverse
+    - dd-validate-dans-bag
+  pollInterval: 5s
 
 
 #


### PR DESCRIPTION
Fixes DD-1772

# Description of changes
* Makes the fetching of available licenses lazy, so they are fetched when first needed. This prevents `dd-dataverse-ingest` from crashing after a server reboot, due to Dataverse starting more slowly than `dd-dataverse-ingest`.
* It turned out that retrieving the active metadata blocks suffered from the same problem. This list is now fetched lazily, as well.
* Introduced a `dependenciesReadyCheck` setting with a list of health checks to verify before proceeding with the next deposit. The health checks added are for Dataverse and for `dd-validate-dans-bag` because no deposit will succeed if they are down (except a non-DANS deposit if only `dd-validate-dans-bag` is down, but we are keeping things simple here). This feature will limit the number of deposits that fail because one of these dependencies is not ready.

# How to test

```
deploy.py -m dd-dataverse-ingest 
```

* Check that the service kan be restarted with Dataverse and/or `dd-validate-dans-bag` down; check the service status after restart.
* Do a reboot and check that all three services come on-line.
* Stop Dataverse and/or validate and start a SWORD deposit (or an import batch). Check the log to see that waits for the dependencies. Start all the dependencies and check that the deposit is processed correctly.

Note that it is still possible for a deposit to fail if Dataverse or validate is stopped when it is already in progress.

# Notify
@DANS-KNAW/core-systems
