### PR TITLE
DD-1785

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-java-utils</artifactId>
-            <version>1.4.2-SNAPSHOT</version>
+            <version>1.5.0</version>
         </dependency>
         <dependency>
             <groupId>nl.knaw.dans</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-java-utils</artifactId>
-            <version>1.4.1</version>
+            <version>1.4.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>nl.knaw.dans</groupId>

--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -39,6 +39,7 @@ dataverse:
 ingest:
   # Deposits dropped in the inbox will automatically be picked up and processed by the ingest service.
   autoIngest:
+    # apiKey: 'changeme' # overrides the apiKey from the dataverse section
     inbox: /var/opt/dans.knaw.nl/tmp/auto-ingest/inbox
     outbox: /var/opt/dans.knaw.nl/tmp/auto-ingest/outbox
     # Forces the service to require the bag in the deposit to conform to the DANS BagIt Profile. Without this SWORD depositors would have the full range of options offered by
@@ -47,6 +48,7 @@ ingest:
   # Import of migration deposits. This area is used to migrate datasets from EASY to Dataverse and differs from import only in the way the DANS deposits are converted
   # to Dataverse Ingest deposits.
   migration:
+    # apiKey: 'changeme' # overrides the apiKey from the dataverse section
     inbox: /var/opt/dans.knaw.nl/tmp/migration/deposits
     outbox: /var/opt/dans.knaw.nl/tmp/migration/out
     # Forces the service to require the bag in the deposit to conform to the DANS BagIt Profile. Without this SWORD depositors would have the full range of options offered by
@@ -54,6 +56,7 @@ ingest:
     requireDansBag: yes
   # Import of deposits. This area is used for manual bulk imports of deposits.
   import:
+    # apiKey: 'changeme' # overrides the apiKey from the dataverse section
     inbox: /var/opt/dans.knaw.nl/tmp/import/inbox
     outbox: /var/opt/dans.knaw.nl/tmp/import/outbox
     # Allow Dataverse Ingest Deposits for import. Import should only be accessible to application manager.

--- a/src/main/java/nl/knaw/dans/dvingest/config/IngestAreaConfig.java
+++ b/src/main/java/nl/knaw/dans/dvingest/config/IngestAreaConfig.java
@@ -28,4 +28,6 @@ public class IngestAreaConfig {
     private Path outbox;
 
     private Boolean requireDansBag = true;
+
+    private String apiKey;
 }


### PR DESCRIPTION
Fixes DD-1785

# Description of changes
It is now possible to override the apiKey used to perform actions on Dataverse per ingest area. This uses the extra parameter added by https://github.com/DANS-KNAW/dans-java-utils/pull/22 .

# Notify
@DANS-KNAW/core-systems
