### PR TITLE
DD-1868 leave-draft

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,3 +18,5 @@ jobs:
         run: mvn -B test
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+        continue-on-error: true
+

--- a/src/main/java/nl/knaw/dans/dvingest/core/dansbag/DansBagMappingService.java
+++ b/src/main/java/nl/knaw/dans/dvingest/core/dansbag/DansBagMappingService.java
@@ -27,6 +27,7 @@ import nl.knaw.dans.lib.dataverse.model.dataset.DatasetVersion;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Optional;
 
 /**
  * Service for mapping a DANS deposit to a standard Dataverse ingest deposit. A DANS deposit has only one bag, which must conform to the DANS BagIt Profile.
@@ -89,12 +90,13 @@ public interface DansBagMappingService {
     EditPermissions getEditPermissionsFromDansDeposit(DansBagDeposit dansDeposit, boolean isUpdate);
 
     /**
-     * Maps the DANS deposit to an update action for the dataset. This determines how to publish the dataset (as migrated or as new).
+     * Maps the DANS deposit to an update action for the dataset. This determines how to publish the dataset (as migrated or as new). It is also possible that
+     * the dataset is not published at all, in which case the update action is empty.
      *
      * @param dansDeposit the DANS deposit
      * @return the update action for the dataset
      */
-    UpdateAction getUpdateActionFromDansDeposit(DansBagDeposit dansDeposit);
+    public Optional<UpdateAction> getUpdateActionFromDansDeposit(DansBagDeposit dansDeposit) throws IOException;
 
     /**
      * Whether this mapper uses the migration mapping or the SWORD/import mapping.

--- a/src/main/java/nl/knaw/dans/dvingest/core/dansbag/DansBagMappingServiceImpl.java
+++ b/src/main/java/nl/knaw/dans/dvingest/core/dansbag/DansBagMappingServiceImpl.java
@@ -280,15 +280,13 @@ public class DansBagMappingServiceImpl implements DansBagMappingService {
             var amd = dansDeposit.getAmd();
 
             if (amd == null) {
-                log.warn("No AMD found for {}", dansDeposit.getDoi());
-                return Optional.empty();
+                throw new RuntimeException(String.format("no AMD found for %s", dansDeposit.getDoi()));
             }
 
             var date = Amd.toPublicationDate(amd);
 
             if (date.isEmpty()) {
-                log.warn("No publication date found in AMD for {}", dansDeposit.getDoi());
-                return Optional.empty();
+                throw new IllegalArgumentException(String.format("no publication date found in AMD for %s", dansDeposit.getDoi()));
             }
 
             return Optional.of(new ReleaseMigratedAction(date.get()));

--- a/src/main/java/nl/knaw/dans/dvingest/core/dansbag/DansDepositProperties.java
+++ b/src/main/java/nl/knaw/dans/dvingest/core/dansbag/DansDepositProperties.java
@@ -45,6 +45,11 @@ public class DansDepositProperties {
         }
     }
 
+    public DansDepositProperties(PropertiesConfiguration properties) {
+        this.properties = properties;
+        this.depositId = properties.getString("depositId");
+    }
+
     public String getSwordToken() {
         return properties.getString("dataverse.sword-token");
     }

--- a/src/main/java/nl/knaw/dans/dvingest/core/dansbag/DansDepositProperties.java
+++ b/src/main/java/nl/knaw/dans/dvingest/core/dansbag/DansDepositProperties.java
@@ -48,4 +48,9 @@ public class DansDepositProperties {
     public String getSwordToken() {
         return properties.getString("dataverse.sword-token");
     }
+
+    public boolean leaveDraft() {
+        return properties.getBoolean("dans-deposit.leave-draft", false);
+    }
+
 }

--- a/src/main/java/nl/knaw/dans/dvingest/core/dansbag/DansDepositSupport.java
+++ b/src/main/java/nl/knaw/dans/dvingest/core/dansbag/DansDepositSupport.java
@@ -122,6 +122,11 @@ public class DansDepositSupport implements Deposit {
 
     @Override
     public void onSuccess(@NonNull String pid, String message) {
+        if (new DansDepositProperties(ingestDataverseIngestDeposit.getDepositProperties()).leaveDraft()) {
+            log.debug("Deposit marked as 'leave-draft', assuming no publish action to be handled");
+            return;
+        }
+
         handlePublishAction(pid, dansBagMappingService.isMigration());
     }
 


### PR DESCRIPTION
Fixes DD-1868

# Description of changes
If `deposit.properties` contains `dans-deposit.leave-draft = true` then `DansDepositConverter` will not generated `update-state.yml`. The bag processing will then leave the dataset version in draft state. `DansDepositSupport.onSuccess` takes this into account by not trying to handle a publish action if 

# Notify
@DANS-KNAW/core-systems
