### PR TITLE
polling of 5 seconds reduces cpu usage

### DIFF
--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -51,9 +51,7 @@ dataverse:
 #
 ingest:
   # Deposits dropped in the inbox will automatically be picked up and processed by the ingest service.
-  p
   autoIngest:
-    pollingInterval: 5000
     # apiKey: 'changeme' # overrides the apiKey from the dataverse section
     inbox: /var/opt/dans.knaw.nl/tmp/auto-ingest/inbox
     outbox: /var/opt/dans.knaw.nl/tmp/auto-ingest/outbox

--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -51,7 +51,9 @@ dataverse:
 #
 ingest:
   # Deposits dropped in the inbox will automatically be picked up and processed by the ingest service.
+  p
   autoIngest:
+    pollingInterval: 5000
     # apiKey: 'changeme' # overrides the apiKey from the dataverse section
     inbox: /var/opt/dans.knaw.nl/tmp/auto-ingest/inbox
     outbox: /var/opt/dans.knaw.nl/tmp/auto-ingest/outbox

--- a/src/main/java/nl/knaw/dans/dvingest/DdDataverseIngestApplication.java
+++ b/src/main/java/nl/knaw/dans/dvingest/DdDataverseIngestApplication.java
@@ -164,6 +164,7 @@ public class DdDataverseIngestApplication extends Application<DdDataverseIngestC
         var depositTaskFactory = new DepositTaskFactoryImpl(bagProcessorFactory, dansDepositSupportFactory, dependenciesReadyCheck);
         var inboxTaskFactory = new InboxTaskFactoryImpl(dataverseIngestDepositFactory, depositTaskFactory, ingestAreaConfig.getOutbox());
         var inbox = Inbox.builder()
+            .interval(ingestAreaConfig.getPollingInterval())
             .inbox(ingestAreaConfig.getInbox())
             .executorService(environment.lifecycle().executorService("auto-ingest").minThreads(1).maxThreads(1).build())
             .taskFactory(inboxTaskFactory).build();

--- a/src/main/java/nl/knaw/dans/dvingest/config/IngestAreaConfig.java
+++ b/src/main/java/nl/knaw/dans/dvingest/config/IngestAreaConfig.java
@@ -30,4 +30,6 @@ public class IngestAreaConfig {
     private Boolean requireDansBag = true;
 
     private String apiKey;
+
+    private int pollingInterval = 5000; // Default polling interval of inbox in milliseconds
 }


### PR DESCRIPTION
Fixes DD-1918: cpu consumption

# Description of changes

Configurable polling interval of ingest box, increased default from 1 second to 5

# How to test

See steps to replicate. Also run sword example 'audience'.

# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/core-systems
