### PR TITLE
DD-2372 SWORD2 with embargo fails in 6.10 DANS patch 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,8 @@
 
     <properties>
         <main-class>nl.knaw.dans.dvingest.DdDataverseIngestApplication</main-class>
-        <dans-java-utils.version>2.10.1</dans-java-utils.version>
-        <dans-dataverse-client-lib.version>1.10.0</dans-dataverse-client-lib.version>
+        <dans-java-utils.version>4.1.0</dans-java-utils.version>
+        <dans-dataverse-client-lib.version>2.2.1</dans-dataverse-client-lib.version>
         <dd-dans-sword2-examples.version>1.2.0</dd-dans-sword2-examples.version>
     </properties>
 

--- a/src/main/java/nl/knaw/dans/dvingest/client/ValidateDansBagServiceImpl.java
+++ b/src/main/java/nl/knaw/dans/dvingest/client/ValidateDansBagServiceImpl.java
@@ -34,8 +34,8 @@ public class ValidateDansBagServiceImpl implements ValidateDansBagService {
 
     public ValidateDansBagServiceImpl(ValidateDansBagConfig config, Environment environment) {
         api = new ClientProxyBuilder<ApiClient, DefaultApi>()
-            .apiClient(new ApiClient())
-            .defaultApiCtor(DefaultApi::new)
+            .apiClientCtor(ApiClient::new)
+            .proxyCtor(DefaultApi::new)
             .httpClient(config.getHttpClient())
             .basePath(config.getUrl()).build();
 

--- a/src/main/java/nl/knaw/dans/dvingest/core/bagprocessor/FilesEditor.java
+++ b/src/main/java/nl/knaw/dans/dvingest/core/bagprocessor/FilesEditor.java
@@ -32,6 +32,7 @@ import nl.knaw.dans.lib.dataverse.model.file.FileMetaUpdate;
 import nl.knaw.dans.lib.util.PathIterator;
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -131,8 +132,7 @@ public class FilesEditor {
             dataverseService.deleteFiles(pid,
                 editFiles.getDeleteFiles().stream()
                     .map(filesInDatasetCache::get)
-                    .mapToInt(file -> file.getDataFile().getId())
-                    .boxed()
+                    .map(file -> file.getDataFile().getId())
                     .collect(Collectors.toList()));
             filesInDatasetCache.removeAll(editFiles.getDeleteFiles());
             log.debug("[{}] End deleting {} files.", depositId, editFiles.getDeleteFiles().size());
@@ -417,11 +417,13 @@ public class FilesEditor {
                 log.debug("[{}] Adding embargo number {}", depositId, i);
                 var embargo = new Embargo();
                 embargo.setDateAvailable(addEmbargo.getDateAvailable());
-                embargo.setReason(addEmbargo.getReason());
+                if (StringUtils.isNotBlank(addEmbargo.getReason())) {
+                    embargo.setReason(addEmbargo.getReason());
+                }
                 var fileIds = addEmbargo.getFilePaths()
                     .stream()
                     .map(filesInDatasetCache::get)
-                    .mapToInt(file -> file.getDataFile().getId()).toArray();
+                    .mapToInt(file -> (int) file.getDataFile().getId()).toArray();
                 embargo.setFileIds(fileIds);
                 dataverseService.addEmbargo(pid, embargo);
                 editFilesLog.getAddEmbargoes().setNumberCompleted(++numberOfEmbargoesAdded);

--- a/src/main/java/nl/knaw/dans/dvingest/core/service/DataverseService.java
+++ b/src/main/java/nl/knaw/dans/dvingest/core/service/DataverseService.java
@@ -47,7 +47,7 @@ public interface DataverseService {
 
     FileMeta replaceFile(String targetDatasetPid, FileMeta fileToReplace, Path replacement) throws DataverseException, IOException;
 
-    void deleteFiles(String pid, List<Integer> ids) throws DataverseException, IOException;
+    void deleteFiles(String pid, List<Long> ids) throws DataverseException, IOException;
 
     String getDatasetUrnNbn(String datasetId) throws IOException, DataverseException;
 

--- a/src/main/java/nl/knaw/dans/dvingest/core/service/DataverseServiceImpl.java
+++ b/src/main/java/nl/knaw/dans/dvingest/core/service/DataverseServiceImpl.java
@@ -118,7 +118,7 @@ public class DataverseServiceImpl implements DataverseService {
     }
 
     @Override
-    public void deleteFiles(String pid, List<Integer> ids) throws DataverseException, IOException {
+    public void deleteFiles(String pid, List<Long> ids) throws DataverseException, IOException {
         var result = dataverseClient.dataset(pid).deleteFiles(ids);
         log.debug(result.getEnvelopeAsString());
     }

--- a/src/test/java/nl/knaw/dans/dvingest/core/bagprocessor/FilesEditorDeleteFilesTest.java
+++ b/src/test/java/nl/knaw/dans/dvingest/core/bagprocessor/FilesEditorDeleteFilesTest.java
@@ -52,7 +52,7 @@ public class FilesEditorDeleteFilesTest extends FilesEditorTestFixture {
         filesEditor.editFiles("pid");
 
         // Then
-        Mockito.verify(dataverseServiceMock).deleteFiles("pid", List.of(1, 3));
+        Mockito.verify(dataverseServiceMock).deleteFiles("pid", List.of(1L, 3L));
         assertThat(filesEditor.getFilesInDatasetCache().get("file1")).isNull();
         assertThat(filesEditor.getFilesInDatasetCache().get("file2")).isNotNull();
         assertThat(filesEditor.getFilesInDatasetCache().get("file3")).isNull();


### PR DESCRIPTION
Fixes DD-2372

# Description of changes
* Use the new version of `dans-dataverse-lib` that leaves the reason field out if it is set to `null`.
* Unrelated: update `dans-java-utils` dependency.


# Notify
@DANS-KNAW/core-systems
